### PR TITLE
Manafnder: Opensea data and sorting refactor

### DIFF
--- a/apollo-client.js
+++ b/apollo-client.js
@@ -1,7 +1,0 @@
-import { ApolloClient, InMemoryCache } from "@apollo/client";
-
-const client = new ApolloClient({
-  cache: new InMemoryCache(),
-  uri: "https://api.thegraph.com/subgraphs/name/treppers/genesisproject"
-});
-export default client;

--- a/apollo-client.ts
+++ b/apollo-client.ts
@@ -1,0 +1,21 @@
+import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from "@apollo/client";
+import { RestLink } from 'apollo-link-rest';
+import { RetryLink } from '@apollo/client/link/retry';
+
+const theGraphLink = new HttpLink({uri:"https://api.thegraph.com/subgraphs/name/treppers/genesisproject"});
+const apiLink = new RestLink({
+  uri:'/api',
+  responseTransformer: response => response.json()
+});
+
+const dispatcherLink = new RetryLink().split(
+  (operation) =>  operation.variables?.restful,
+  apiLink,
+  theGraphLink
+);
+
+const client = new ApolloClient({
+  cache: new InMemoryCache(),
+  link: dispatcherLink
+});
+export default client;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "^6.2.4",
+    "apollo-link-rest": "^0.8.0-beta.0",
     "ethers": "^5.4.7",
     "graphql": "^15.6.0",
     "lodash": "^4.17.21",

--- a/pages/manafinder/[[...slug]].tsx
+++ b/pages/manafinder/[[...slug]].tsx
@@ -10,86 +10,18 @@ import suffices from '@data/suffices.json'
 import inventory from '@data/inventory.json'
 import { ManaInfo, fetchMana } from '@api/mana'
 import { BagInfo, fetchBags } from '@api/bags'
-import { GetStaticProps, GetStaticPaths } from 'next'
 // import { format as ts } from 'timeago.js'
 
 // Types
 import type { ReactElement } from "react";
 import type {Mana, ManaVars, ManaData, Bag, BagData, BagVars, Wallet, TokenListProps} from '@utils/manaFinderTypes'
 
-export const getStaticProps: GetStaticProps = async (context) => {
-  let openseaGMData = await fetchMana()
-  // let openseaLootData = await fetchBags()
-  return {
-    props: {
-      openseaGMData: openseaGMData.mana.reduce((ctx, manaInfo: ManaInfo) => {
-        ctx[manaInfo.id] = manaInfo;
-        return ctx;
-      }, {} as Map<string, ManaInfo>),
-      // openseaLootData: openseaLootData.bags.reduce((ctx, bagInfo: BagInfo) => {
-      //   ctx[bagInfo.id] = bagInfo;
-      //   return ctx;
-      // }, {} as Map<string, BagInfo>)
-    },
-  }
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: true
-  }
-}
-
 export default function Home(props): ReactElement {
   const router = useRouter();
-  const slug = router.query.slug;
   const [suffixId, inventoryId] = (
     (router.query.slug as string[]) || ["-1", "-1"]
   ).map((val) => (val ? parseInt(val) : 0));
 
-  const inventoryName = (inventoryId >= 0) ? inventory[inventoryId].label.toLowerCase() : 'weapon';
-  const inventoryNameSuffix = inventoryName + "SuffixId";
-
-  const GET_CLAIMED_MANA = gql`
-  query GetClaimedMana($suffixId: Int!, $inventoryId: Int!) {
-    manas(where: {suffixId: $suffixId, inventoryId: $inventoryId, currentOwner_not_in:
-        ["0x1884d71487bfd7f595061221801e783efcd0bf6a",
-         "0x9bbda2777c8623d8894b21120bed1fff72b024f8",
-         "0xb6b3eb3ec30bd8979df60d7f47b173a389310dd9",
-         "0xc3e33b881aea922bce6df56bc2c6f0686a3a421a",
-         "0xdcab536df6dd9ad5d332180edf1ba1ec71669ae2",
-         "0x4cf7e239f5bc882e007d9790a7b49b4abdfeb510",
-         "0x338aef050ac689246490aa75b691ac03fe0a81c8",
-         "0xea0a3aae1dda17d0a17a488196801f59ca96854c",
-         "0x1f5fe23574d5aec1660a8c6b209135da5723042f",
-         "0xd431a116a7d0eca9371614d5652cdfffb7c5b6eb",
-         "0x0780529f0ecfac1048d2faae5007fe62ce318c79",
-         "0xf935c944a8e03181ae3229774d4b93d7bba816d4",
-         "0xaba619a78032abcfe0346c1592835df563ba3bfa",
-         "0xe1e5072fc1ff1a419d17bf9b5c5b6ddd12c19f08",
-         "0x17498d27433849a510165cc1fc618582ac54229b",
-         "0xb1dea25cb8b997913f86076b372aa75f06c53c99"]}) {
-      id
-      itemName
-      currentOwner {
-        id
-      }
-    }
-  }
-  `;
-
-  const GET_UNCLAIMED_MANA = gql`
-  query GetUnclaimedMana($suffixId: Int!) {
-    bags(where: {manasClaimed: 0, ${inventoryNameSuffix}: $suffixId}) {
-      id
-      itemName: ${inventoryName}
-      currentOwner {
-        id
-      }
-    }
-  }
-  `;
 
   const onChangeSuffixId = (item: any) => {
     router.push(`/manafinder/${item.value || 0}/${inventoryId}`, undefined, { shallow: true });
@@ -99,41 +31,7 @@ export default function Home(props): ReactElement {
     router.push(`/manafinder/${suffixId}/${item.value || 0}`, undefined, { shallow: true });
   };
 
-  const { loading:cLoading, data:cData, error: cError } = useQuery<ManaData, ManaVars>(
-    GET_CLAIMED_MANA,
-    { variables: { suffixId: suffixId, inventoryId: inventoryId } }
-  );
-
-  const { loading:ucLoading, data:ucData, error: ucError } = useQuery<BagData, BagVars>(
-    GET_UNCLAIMED_MANA,
-    { variables: { suffixId: suffixId } }
-  );
-
-  let claimedTableData = null;
-  let unclaimedTableData = null;
-  if(!cLoading && cData) {
-    claimedTableData = cData.manas.map((i)=> {
-      return {
-        id: Number(i.id),
-        name: i.itemName,
-        address: i.currentOwner.id,
-        price: props.openseaGMData[i.id]?.price
-      }
-    });
-  }
-
-
-  if(!ucLoading && ucData) {
-    unclaimedTableData = ucData.bags.map((i)=> {
-      return {
-        id: Number(i.id),
-        name: i.itemName,
-        address: i.currentOwner.id,
-        price: 0 //props.openseaLootData[i.id]?.price
-      }
-    });
-  }
-
+ 
   return (
     <Layout>
       <div>
@@ -171,16 +69,155 @@ export default function Home(props): ReactElement {
               options={inventory}
             />
           </div>
-          <h2>Claimed Mana</h2>
-          {cLoading ? <p>Loading ...</p> : <TokenList name ="Mana" data={claimedTableData} address="0xf4b6040a4b1b30f1d1691699a8f3bf957b03e463"/>}
-          <h2>Unclaimed Mana</h2>
-          {ucLoading ? <p>Loading ...</p> : <TokenList name="Loot" data={unclaimedTableData} address="0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7"/>}
+          <ClaimedMana suffixId={suffixId} inventoryId={inventoryId} />
+          <UnClaimedMana suffixId={suffixId} inventoryId={inventoryId} />
         </div>
       </div>
     </Layout>
   );
 }
 
+
+function ClaimedMana(props: {suffixId:number, inventoryId:number}) {
+  const { loading, data, error } = useClaimedMana(props.suffixId, props.inventoryId);
+  const { data: openseaData } = useOpenseaManaData((data?.manas ?? []).map(mana => mana.id.toString()));
+
+  const tableData = (data?.manas??[]).map((item) => ({
+    id: Number(item.id),
+    name: item.itemName,
+    address: item.currentOwner?.id,
+    price: openseaData?.queryManas?.manas?.find(mana => mana.id == item.id)?.price ?? -1
+  }));
+
+  return (
+    <div>
+      <h2>Claimed Mana</h2>
+      {loading ? <p>Loading ...</p> : <TokenList name ="Mana" data={tableData} address="0xf4b6040a4b1b30f1d1691699a8f3bf957b03e463"/>}
+    </div>
+  );
+}
+
+function UnClaimedMana(props: {suffixId:number, inventoryId:number}) {
+  const { loading, data, error } = useUnclaimedMana(props.suffixId, props.inventoryId);  
+  const { data: openseaData } = useOpenseaBagsData((data?.bags ?? []).map(bag => bag.id.toString()));
+
+  const tableData = (data?.bags??[]).map((item) => ({
+    id: Number(item.id),
+    name: item.itemName,
+    address: item.currentOwner?.id,
+    price: openseaData?.queryBags?.bags?.find(bag => bag.id == item.id)?.price ?? -1
+  }));
+
+  return (
+    <div>
+      <h2>Unclaimed Mana</h2>
+      {loading ? <p>Loading ...</p> : <TokenList name ="Loot" data={tableData} address="0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7"/>}
+    </div>
+  );
+}
+
+
+function useClaimedMana(suffixId, inventoryId) {
+  const [claimedMana, setClaimedMana] = useState();
+
+  const GET_CLAIMED_MANA = gql`
+  query GetClaimedMana($suffixId: Int!, $inventoryId: Int!) {
+    manas(where: {suffixId: $suffixId, inventoryId: $inventoryId, currentOwner_not_in:
+        ["0x1884d71487bfd7f595061221801e783efcd0bf6a",
+         "0x9bbda2777c8623d8894b21120bed1fff72b024f8",
+         "0xb6b3eb3ec30bd8979df60d7f47b173a389310dd9",
+         "0xc3e33b881aea922bce6df56bc2c6f0686a3a421a",
+         "0xdcab536df6dd9ad5d332180edf1ba1ec71669ae2",
+         "0x4cf7e239f5bc882e007d9790a7b49b4abdfeb510",
+         "0x338aef050ac689246490aa75b691ac03fe0a81c8",
+         "0xea0a3aae1dda17d0a17a488196801f59ca96854c",
+         "0x1f5fe23574d5aec1660a8c6b209135da5723042f",
+         "0xd431a116a7d0eca9371614d5652cdfffb7c5b6eb",
+         "0x0780529f0ecfac1048d2faae5007fe62ce318c79",
+         "0xf935c944a8e03181ae3229774d4b93d7bba816d4",
+         "0xaba619a78032abcfe0346c1592835df563ba3bfa",
+         "0xe1e5072fc1ff1a419d17bf9b5c5b6ddd12c19f08",
+         "0x17498d27433849a510165cc1fc618582ac54229b",
+         "0xb1dea25cb8b997913f86076b372aa75f06c53c99"]}) {
+      id
+      itemName
+      currentOwner {
+        id
+      }
+    }
+  }
+  `;
+  return useQuery<ManaData, ManaVars>(
+    GET_CLAIMED_MANA,
+    { variables: { suffixId: suffixId, inventoryId: inventoryId } }
+  );
+}
+
+function useUnclaimedMana(suffixId, inventoryId) {
+  const inventoryName = (inventoryId >= 0) ? inventory[inventoryId].label.toLowerCase() : 'weapon';
+  const inventoryNameSuffix = inventoryName + "SuffixId";
+
+  const GET_UNCLAIMED_MANA = gql`
+  query GetUnclaimedMana($suffixId: Int!) {
+    bags(where: {manasClaimed: 0, ${inventoryNameSuffix}: $suffixId}) {
+      id
+      itemName: ${inventoryName}
+      currentOwner {
+        id
+      }
+    }
+  }
+  `;
+  
+  return useQuery<BagData, BagVars>(
+    GET_UNCLAIMED_MANA,
+    { variables: { suffixId: suffixId } }
+  );
+}
+
+function useOpenseaManaData(tokenIds:string[]) {
+  const GET_OPENSEA_MANA_DATA = gql`
+  query GetOpenSeaManaData ($tokenIds: String) {
+    queryManas(tokenIds: $tokenIds) @rest(type: "OpenSeaManaData", method:"GET", path: "/mana?tokenIds={args.tokenIds}" ) {
+      manas {
+        id
+        url
+        price
+      }
+      lastUpdate
+    }
+  }
+  `;
+
+  return useQuery(GET_OPENSEA_MANA_DATA, {
+    variables: {
+      tokenIds: (tokenIds ?? []).join(','),
+      restful: true,
+    }
+  });
+}
+
+function useOpenseaBagsData(tokenIds:string[]) {
+  const GET_OPENSEA_BAGS_DATA = gql`
+  query GetOpenSeaBagsData ($tokenIds: String) {
+    queryBags(tokenIds: $tokenIds) @rest(type: "OpenSeaBagsData", method:"GET", path: "/bags?tokenIds={args.tokenIds}" ) {
+      bags {
+        id
+        url
+        price
+      }
+      lastUpdate
+    }
+  }
+  `;
+
+  return useQuery(GET_OPENSEA_BAGS_DATA, {
+    variables: {
+      tokenIds: (tokenIds ?? []).join(','),
+      restful: true,
+    }
+  });
+}
 
 function shortenAddress(address: string) {
   return address.slice(0, 6) + '…' + address.slice(-4)
@@ -217,7 +254,6 @@ const useSortableData = (items, config = null) => {
 
 function TokenList(props: TokenListProps): ReactElement {
   const data = props.data;
-
   const { items: sortedData, requestSort, sortConfig } = useSortableData(data, {key: 'id', direction: 'ascending'})
   const getClassNamesFor = (name) => {
      if (!sortConfig) {
@@ -243,7 +279,7 @@ function TokenList(props: TokenListProps): ReactElement {
               <td className={styles.tokenId}><a href={"//opensea.io/assets/"+ props.address + "/" + item.id}  target="_blank" rel="noopener noreferrer">{item.id}</a></td>
               <td>{item.name}</td>
               <td><a href={"//opensea.io/" + item.address}  target="_blank" rel="noopener noreferrer">{shortenAddress(item.address)}</a></td>
-              <td className={[styles.price,(item.price ? styles.eth : '')].join(" ")}>{(item.price ? item.price : "--")}</td>
+              <td className={[styles.price,(item.price ? styles.eth : '')].join(" ")}>{(item.price && item.price > 0 ? item.price : "--")}</td>
             </tr>
           ))}
       </tbody>

--- a/utils/manaFinderTypes.ts
+++ b/utils/manaFinderTypes.ts
@@ -33,7 +33,7 @@ export interface Wallet {
 }
 
 export interface TokenListProps {
-  data?: Mana[] | Bag[];
+  data?: any[];
   name: string;
   address: string;
 }


### PR DESCRIPTION
- Remove getStatic... methods. 
- Expose tokenIds parameter to /api/bags and /api/mana, so we don't have to pull entire collection
- Expose mana/bags api as an RestLink(https://www.apollographql.com/docs/react/api/link/apollo-link-rest/) so we can query via ApolloClient and take advantage of it's caching.
`
return useQuery(..., {
    variables: {
      ....,
      restful: true, // <-- to dispatch to restful
    }
  });
`
- Component refactoring
- Fix sorting. 